### PR TITLE
chore: bump zod to 4.4.3 and use .optional()

### DIFF
--- a/_data/eleventyDataSchema.js
+++ b/_data/eleventyDataSchema.js
@@ -5,7 +5,7 @@ export default function (data) {
   // Draft content, validate `draft` front matter
   let result = z
     .object({
-      draft: z.boolean().or(z.undefined()),
+      draft: z.boolean().optional(),
     })
     .safeParse(data);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@11ty/eleventy-plugin-rss": "3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
         "luxon": "3.7.2",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
         "zod-validation-error": "5.0.0"
       }
     },
@@ -2377,9 +2377,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@11ty/eleventy-plugin-rss": "3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
     "luxon": "3.7.2",
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "zod-validation-error": "5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `zod` from 4.3.6 to 4.4.3.
- Use the idiomatic `z.boolean().optional()` instead of `z.boolean().or(z.undefined())` in the eleventy data schema.

## Test plan
- [ ] `npm install` resolves without errors
- [ ] Site builds successfully (`npm run build`)
- [ ] Schema validation still passes for posts with and without an explicit `draft` field